### PR TITLE
Use the raw line for debug logs.

### DIFF
--- a/irc/debugHandler.go
+++ b/irc/debugHandler.go
@@ -2,7 +2,6 @@ package irc
 
 import (
 	"log"
-	"strings"
 )
 
 type debugHandler struct {
@@ -22,7 +21,7 @@ func (h *debugHandler) install(c *Connection) {
 
 func (h *debugHandler) handleMessage(_ *Connection, m *Message) {
 	if h.debug {
-		log.Printf("In : %s %s %s", m.Source, m.Verb, strings.Join(m.Params, " "))
+		log.Printf("In : %s", m.Raw)
 	}
 }
 


### PR DESCRIPTION
Fixes #nothing

## Proposed Changes

I hereby propose that instead of reconstructing the
line badly from the parsed data, we log the actual
raw line.