### PR TITLE
Fix panic on lines that only have tags.

### DIFF
--- a/irc/parser.go
+++ b/irc/parser.go
@@ -6,13 +6,10 @@ import (
 
 func (irc *Connection) parseMessage(line string) *Message {
 	line = strings.TrimRight(line, "\r\n")
-	if len(line) < 5 {
-		return nil
-	}
-	message := &Message{
-		Raw: line,
-	}
-	if line[0] == '@' {
+	message := &Message{Raw: line}
+
+	// Parse IRCv3 tags
+	if len(line) > 0 && line[0] == '@' {
 		if i := strings.Index(line, " "); i > -1 {
 			message.Tags = line[1:i]
 			line = line[i+1:]
@@ -20,7 +17,9 @@ func (irc *Connection) parseMessage(line string) *Message {
 			return nil
 		}
 	}
-	if line[0] == ':' {
+
+	// Parse the message prefix
+	if len(line) > 0 && line[0] == ':' {
 		if i := strings.Index(line, " "); i > -1 {
 			message.Source = line[1:i]
 			line = line[i+1:]
@@ -30,6 +29,12 @@ func (irc *Connection) parseMessage(line string) *Message {
 	} else {
 		message.Source = irc.ClientConfig.Server
 	}
+
+	if len(line) == 0 {
+		return nil
+	}
+
+	// Parse the command and its arguments
 	split := strings.SplitN(line, " :", 2)
 	args := strings.Split(split[0], " ")
 	message.Verb = strings.ToUpper(args[0])


### PR DESCRIPTION
A line such as "@abcde" caused a panic as it first parses out the
tag, then tries to index into the remainder to check for a prefix.
